### PR TITLE
Removed manual bundle install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 cache: bundler
 rvm: 2.4.1
-before_script:
-  - bundle install
 script:
   - bundle exec awesome_bot README.md --white-list travis-ci.org,awesome.re
   - bundle exec danger


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-vapor 🙇 -->

<!-- Please fill out the short form below -->

<!-- To mark the checkboxes as completed, put an `x` inside the squared brackets, like so: [x] -->

Apparently calling `bundle install` is not needed as Travis runs that command automatically anytime `Gemfile` is present in repository.

- **Project Name**: N/A
- **Project URL**: N/A
- **Project Description**: N/A
- **Why it should be added to `awesome-vapor`**: N/A
- [ ] Project has at least 15 stars (if it's a GitHub project)
- [ ] Project supports Swift 4
- [ ] Project supports at least Vapor 2
- [ ] I used correctly sized dash and ended the entry with a full stop 🤓
