### PR TITLE
Added Imperial entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Simply press <kbd>Command</kbd> + <kbd>F</kbd> to search for a keyword.
 - ![v2](img/vapor-2.png) [Flash](https://github.com/nodes-vapor/flash) – Flash messages between views.
 - ![v2](img/vapor-2.png) [Forms](https://github.com/nodes-vapor/forms) – Tools for working with Forms in Vapor.
 - ![v2](img/vapor-2.png) [Gatekeeper](https://github.com/nodes-vapor/gatekeeper) – Rate limiting middleware for Vapor.
+- ![v3](img/vapor-3.png) [Imperial](https://github.com/vapor-community/Imperial) – Federated Authentication with OAuth providers.
 - ![v2](img/vapor-2.png) [JWT Keychain](https://github.com/nodes-vapor/jwt-keychain) – Easily scaffold a keychain using JWT for Vapor.
 - ![v2](img/vapor-2.png) [Leaf Error Middleware](https://github.com/brokenhandsio/leaf-error-middleware) – Serve up custom 404 and server error pages for your Vapor App.
 - ![v2](img/vapor-2.png) [Lingo Provider](https://github.com/vapor-community/Lingo-Provider) – Vapor provider for Lingo – the Swift localization library.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-vapor 🙇 -->

<!-- Please fill out the short form below -->

<!-- To mark the checkboxes as completed, put an `x` inside the squared brackets, like so: [x] -->

- **Project Name**: Imperial
- **Project URL**: https://github.com/vapor-community/Imperial
- **Project Description**: Federated Authentication with OAuth providers
- **Why it should be added to `awesome-vapor`**: While Imperial supports only Google and GitHub OAuth providers for now, I think it's a project that will be of interest to many developers fighting with OAuth-based solutions.
- [x] Project has at least 15 stars (if it's a GitHub project)
- [x] Project supports Swift 4
- [x] Project supports at least Vapor 2
- [x] I used correctly sized dash and ended the entry with a full stop 🤓
