### PR TITLE
Updated name and URL of Ferno/Firebase Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Simply press <kbd>Command</kbd> + <kbd>F</kbd> to search for a keyword.
 - ![v2](img/vapor-2.png) [AWS](https://github.com/nodes-vapor/aws) – Swift wrapper around AWS API.
 - ![v2](img/vapor-2.png) ![v3](img/vapor-3.png) [Bugsnag](https://github.com/nodes-vapor/bugsnag) – Report errors with Bugsnag.
 - ![v3](img/vapor-3.png) [CSV Framework](https://github.com/skelpo/CSV) – A simple framework to read and write CSV files.
-- ![v3](img/vapor-3.png) [Firebase Provider](https://github.com/vapor-community/firebase-provider) – Vapor Firebase Realtime database provider.
+- ![v3](img/vapor-3.png) [Ferno](https://github.com/vapor-community/ferno) – Vapor Firebase Realtime database provider.
 - ![v2](img/vapor-2.png) ![v3](img/vapor-3.png) [Flash](https://github.com/nodes-vapor/flash) – Flash messages between views.
 - ![v2](img/vapor-2.png) [Forms](https://github.com/nodes-vapor/forms) – Tools for working with Forms in Vapor.
 - ![v2](img/vapor-2.png) [Gatekeeper](https://github.com/nodes-vapor/gatekeeper) – Rate limiting middleware for Vapor.


### PR DESCRIPTION
Just a small update to reflect Ferno's name and URL change.